### PR TITLE
Fix invalid tag name

### DIFF
--- a/libs/apollo-client/package.json
+++ b/libs/apollo-client/package.json
@@ -17,7 +17,7 @@
     "@graphql-sse/client": "^0.0.16"
   },
   "peerDependencies": {
-    "@apollo/client": "^3x"
+    "@apollo/client": "3.x"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
This change will fix the error `Invalid tag name "^3x" of package "@apollo/client@^3x": Tags may not have any characters that encodeURIComponent encodes.` which occurs when you try to install the package.